### PR TITLE
don't double nest singleton FiniteSets from solve.

### DIFF
--- a/algebra_with_sympy/algebraic_equation.py
+++ b/algebra_with_sympy/algebraic_equation.py
@@ -658,6 +658,11 @@ def solve(f, *symbols, **flags):
             return solns[0]
         return solns
     else:
+        if len(solns) == 1:
+            # do not wrap a singleton in FiniteSet if it already is
+            for k in solns:
+                if isinstance(k, FiniteSet):
+                    return k
         return FiniteSet(*solns)
 
 def solveset(f, symbols, domain=sympy.Complexes):

--- a/tests/test_algebraic_equation.py
+++ b/tests/test_algebraic_equation.py
@@ -282,9 +282,9 @@ def test_solve():
     e1 = Eqn(Tp, pi / (wn*sqrt(1 - xi**2)))
     e2 = Eqn(Ts, 4 / (wn*xi))
     algwsym_config.output.solve_to_list = False
-    assert solve([e1, e2], [xi, wn]) == FiniteSet(FiniteSet(
+    assert solve([e1, e2], [xi, wn]) == FiniteSet(
         Eqn(xi, 4*Tp/sqrt(16*Tp**2 + pi**2*Ts**2)),
-        Eqn(wn, sqrt(16*Tp**2 + pi**2*Ts**2)/(Tp*Ts))))
+        Eqn(wn, sqrt(16*Tp**2 + pi**2*Ts**2)/(Tp*Ts)))
     algwsym_config.output.solve_to_list = True
     assert solve([e1, e2], [xi, wn]) == [
         Eqn(xi, 4*Tp/sqrt(16*Tp**2 + pi**2*Ts**2)),


### PR DESCRIPTION
What you did works, but I think we should also make it so that singleton FiniteSets are not wrapped in an extraneous FiniteSet. This pull request adds that. If it looks good to you, merge it into your issue_27 branch and then I will merge that with the current development branch. I probably will not release these and a couple of other fixes for a few weeks.